### PR TITLE
#13570 improve google drive endpoint to return the complete response to platform

### DIFF
--- a/endpoint.json
+++ b/endpoint.json
@@ -26,6 +26,7 @@
     "configurationHelpUrl": "/endpoints_google_drive.html",
     "status": "ACTIVE",
     "stores": [
+        { "name": "googleDriveStore" }
     ],
     "events": [
         {

--- a/src/main/java/io/slingr/endpoints/googledrive/GoogleDriveEndpoint.java
+++ b/src/main/java/io/slingr/endpoints/googledrive/GoogleDriveEndpoint.java
@@ -65,7 +65,7 @@ public class GoogleDriveEndpoint extends PerUserEndpoint {
     @EndpointProperty
     private String redirectUri;
 
-    @EndpointProperty(name = "single")
+    @EndpointProperty
     private String clientType;
 
     @EndpointProperty


### PR DESCRIPTION
Pull request for the topic https://github.com/slingr-stack/platform/issues/13570 created by @pasaperez-slingr 

## What does it do?

Reported error related to the user not being able to log out correctly. 
The problem was that the DataStore was not being referenced correctly, since it was not declared in the `endpoint.json`. So the user data was not clear where to delete it from.

## How to test it?

Implement the endpoint and in the runtime connect and disconnect from the `My Integrations` option.

## Implementation notes

Create a new tags changing the minor version of the endpoint.

## Deployment notes

N/A